### PR TITLE
Fix layout of Resources Cards

### DIFF
--- a/src/components/Resources/ResourceCard.js
+++ b/src/components/Resources/ResourceCard.js
@@ -51,17 +51,12 @@ export const ResourceCard = ({ title, created, description, url }) => {
     setExpanded(!expanded);
   };
   return (
-    <Card class={classes.card}>
+    <Card id={classes.card}>
       <CardHeader
         avatar={
           <Avatar aria-label="recipe" className={classes.avatar}>
             R
           </Avatar>
-        }
-        action={
-          <IconButton aria-label="settings">
-            <MoreVertIcon />
-          </IconButton>
         }
         title={title}
         subheader={created}
@@ -83,6 +78,11 @@ export const ResourceCard = ({ title, created, description, url }) => {
             <LinkIcon />
           </a>
         </IconButton>
+
+        <IconButton aria-label="settings">
+          <MoreVertIcon />
+        </IconButton>
+
         <IconButton
           className={clsx(classes.expand, {
             [classes.expandOpen]: expanded

--- a/src/components/Resources/index.js
+++ b/src/components/Resources/index.js
@@ -27,17 +27,17 @@ function Resources() {
       {console.log(resources)}
 
       <Grid container spacing={1}>
-        <Grid item lg={3}>
+        <Grid item lg={2}>
           <PersonalMenu />
         </Grid>
-        <Grid item lg={9}>
+        <Grid item lg={10}>
           <h2>Resources</h2>
           <Search label="Search resources" />
           <br />
           <Grid container spacing={1}>
             {resources.map(resource => {
               return (
-                <Grid item lg={3} key={resource.id}>
+                <Grid item lg={4} key={resource.id}>
                   <ResourceCard {...resource} />
                 </Grid>
               );


### PR DESCRIPTION
This will help the layout of the resources cards. There was components that were hidden and would be better located at the bottom of the card. 

The Resource Card Header had the property class instead of id being used for classes.card which was causing the material styles to not be applied properly.