### PR TITLE
add slightly darker accessible blue colors for link tag

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -22,5 +22,10 @@
 }
 
 a:link {
+  color: #00008b;
   text-decoration: none;
+}
+
+a:visited {
+  color: #6807f9;
 }


### PR DESCRIPTION
Add slightly darker accessible blue colors for HTML Link tag.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description
The default `dodgerblue` color on codebuddies.org is not very accessible against a white background (or with white font against its blue); 

This PR fixes the issue by adding a slightly darker blue for our links

## Related Tickets & Documents
issue #11

